### PR TITLE
Improve data sync

### DIFF
--- a/deployment/app/src/main/java/com/rk/amii/workers/TaskRunner.java
+++ b/deployment/app/src/main/java/com/rk/amii/workers/TaskRunner.java
@@ -3,11 +3,10 @@ package com.rk.amii.workers;
 import android.content.Context;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
-import androidx.work.ListenableWorker.Result;  // Add this import for Result
+import androidx.work.ListenableWorker.Result;
 import androidx.work.Worker;
 import androidx.work.WorkerParameters;
 
@@ -150,7 +149,6 @@ public class TaskRunner extends Worker {
     @NonNull
     @Override
     public Result doWork() {
-        // Do your background syncing logic here
         boolean isOnline = Utils.isNetworkAvailable(getApplicationContext());
 
         DBHandler dbHandler = new DBHandler(getApplicationContext());
@@ -222,6 +220,7 @@ public class TaskRunner extends Worker {
                 }
             }
 
+            // Show success notification
             if (hasUnuploadedData) {
                 new Handler(Looper.getMainLooper()).post(() ->
                         Toast.makeText(


### PR DESCRIPTION
This is PR for https://github.com/kartoza/miniSASS/issues/1194

I actually have set the task to run uniquely, meaning another sync will not run if miniSASS is currently syncing. But because in @dimasciput, there seemed to be no unsynced data existed, the sync appeared to run multiple times.
https://github.com/user-attachments/assets/3696c9c5-cbf2-4081-91f1-5e7fdc2bb47c

What I'm updating in PR is showing the sync toast only of there is data to be synced.
https://github.com/user-attachments/assets/41e5d2d7-7ee8-45a9-9822-08f2fa6b9366



